### PR TITLE
Remove cancelling of sagas

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -1,10 +1,6 @@
 'use strict';
 
 exports.__esModule = true;
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; /* eslint no-console: ["error", { allow: ["error"] }] */
-
-
 exports.default = router;
 
 var _effects = require('redux-saga/effects');
@@ -23,6 +19,7 @@ var _createHistoryChannel2 = _interopRequireDefault(_createHistoryChannel);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+/* eslint no-console: ["error", { allow: ["error"] }] */
 var INIT = 'INIT';
 var LISTEN = 'LISTEN';
 var BEFORE_HANDLE_LOCATION = 'BEFORE_HANDLE_LOCATION';
@@ -37,7 +34,6 @@ function router(history, routes) {
   var routeMatcher = (0, _buildRouteMatcher2.default)(routes);
   var historyChannel = null;
   var lastMatch = null;
-  var lastSaga = null;
   var pendingBeforeRouteChange = null;
   var currentLocation = null;
 
@@ -54,15 +50,6 @@ function router(history, routes) {
     };
   }
 
-  function deepEqual(x, y) {
-    var ok = Object.keys,
-        tx = typeof x === 'undefined' ? 'undefined' : _typeof(x),
-        ty = typeof y === 'undefined' ? 'undefined' : _typeof(y);
-    return x && y && tx === 'object' && tx === ty ? ok(x).length === ok(y).length && ok(x).every(function (key) {
-      return deepEqual(x[key], y[key]);
-    }) : x === y;
-  }
-
   return (0, _fsmIterator3.default)(INIT, (_fsmIterator = {}, _fsmIterator[INIT] = function () {
     return {
       value: (0, _effects.call)(_createHistoryChannel2.default, history),
@@ -71,10 +58,6 @@ function router(history, routes) {
   }, _fsmIterator[LISTEN] = function (effects) {
     if (effects && !historyChannel) {
       historyChannel = effects;
-    }
-
-    if (effects instanceof Array) {
-      lastSaga = effects[0];
     }
 
     if ('beforeRouteChange' in options) {
@@ -116,34 +99,15 @@ function router(history, routes) {
     var match = routeMatcher.match(path);
     var effects = [];
 
-    var onlyQueryParamChange = false;
-
-    // Ensuring both match and lastMatch are not null before navigating keys in the 'else if'
-    if (lastMatch === null || match === null) {
-      onlyQueryParamChange = false;
-    } else if (match.index === lastMatch.index && deepEqual(lastMatch.params, match.params)) {
-      // If the indexs match, the root path has not changed
-      // and if the url params are the same then those have not changed either.
-      // The only other option that would trigger HANDLE_LOCATION
-      // is if only the query params were changed.
-      onlyQueryParamChange = true;
-    }
-
     while (match !== null) {
       lastMatch = match;
       effects.push((0, _effects.spawn)(match.action, match.params));
       match = options.matchAll ? match.next() : null;
     }
 
-    // This cancels any running sagas unless the only change in
-    // the location is the query params.
-    if (lastSaga && !onlyQueryParamChange) {
-      effects.push((0, _effects.cancel)(lastSaga));
-    }
-
     if (effects.length > 0) {
       return {
-        value: (0, _effects.all)(effects),
+        value: effects,
         next: LISTEN
       };
     }


### PR DESCRIPTION
Accomplishes 2 things

1) Removes logic I added 4 months ago that to handle dynamic cancelling of sagas if query params changed
  - We are handling this in FEBES itself now
2) Removing all logic around cancelling sagas
  - We are also handling this in FEBES itself now (see the `routes.js` file)